### PR TITLE
Removed parameters that isn't set from the send request url.

### DIFF
--- a/WebApiTestClient/WebApiTestClient/Scripts/WebApiTestClient.js
+++ b/WebApiTestClient/WebApiTestClient/Scripts/WebApiTestClient.js
@@ -156,6 +156,20 @@ function SendRequest(httpMethod, url, requestHeaders, requestBody, handleRespons
         return false;
     }
 
+	// Remove parameters with placeholder from the query parameters, since they should be empty for optional parameters.
+    var urlParts = url.split("?");
+    if (urlParts.length > 1) {
+        var resultQuery = [];
+        var queryParameters = urlParts[1].split("&");
+        for (var i = 0; i < queryParameters.length; ++i) {
+            // Add this parameter to the result only if it contains value.
+            if (!/{.*}/.test(queryParameters[i])) {
+                resultQuery.push(queryParameters[i]);
+            }
+        }
+        url = urlParts[0] + "?" + resultQuery.join("&");
+    }
+	
     var httpRequest = new XMLHttpRequest();
     try {
         httpRequest.open(httpMethod, encodeURI(url), false);


### PR DESCRIPTION
Hello. 

First of all thanks for application, it works great.

I found one problem with optional parameters of string type (parameters of other type works fine).
My api has string parameter lang, it is optional and null by default. 
If user doesn't enter this parameter in test client then it will be sent like lang={lang} that isn't very convinient. 

Probably would be better just ignore parameters without set values. 
I have added next code in SendRequest method (WebApiTestClient.js)
I am not very good in js, so probably it can be implemented in a better way.

Maybe this changes will be useful for other.
Thanks.
