### PR TITLE
Support for complex parameters in [FromUri]

### DIFF
--- a/WebApiTestClient/WebApiTestClient/Areas/HelpPage/Views/Help/DisplayTemplates/TestClientDialogs.cshtml.pp
+++ b/WebApiTestClient/WebApiTestClient/Areas/HelpPage/Views/Help/DisplayTemplates/TestClientDialogs.cshtml.pp
@@ -75,8 +75,18 @@
             {
               if (parameter.Source == System.Web.Http.Description.ApiParameterSource.FromUri)
               {
-                    @:{ name: "@parameter.Name", value: "" },
-                }
+                  if (parameter.ParameterDescriptor.ParameterType.IsClass)
+                  {
+                      foreach (var property in parameter.ParameterDescriptor.ParameterType.GetProperties())
+                      {
+                          @:{ name: "@property.Name", value: "" },
+                      }
+                  }
+                  else
+                  {
+                      @:{ name: "@parameter.Name", value: "" },
+                  }
+              }
             }
     ],
     Samples: {


### PR DESCRIPTION
Usage example:
public class MyValuesRequest
{
public DateTime from { get; set; }
public DateTime to { get; set; }
}

[Route("my/{myKey}/values")]
public List<MyValue> GetMyValues(Guid myKey, [FromUri]MyValuesRequest
data)

Now you can test request:
my/{myKey}/values?from={from}&to={to}
