### PR TITLE
Issue #13 fix: Clean up URI path with query string off ampersands left by dis-selecting optional parameters

### DIFF
--- a/WebApiTestClient/WebApiTestClient/Scripts/WebApiTestClient.js
+++ b/WebApiTestClient/WebApiTestClient/Scripts/WebApiTestClient.js
@@ -26,6 +26,9 @@ var emptyTestClientModel =
         }
 
         // cleanup path
+        while (path.indexOf("&&") >= 0) {
+            path = path.replace("&&", "&");
+        }
         path = path.replace("/?", "?");
         path = path.replace("?&", "?");
 


### PR DESCRIPTION
Issue #13 fix:
- Clean up URI path with query string off ampersands left by dis-selecting optional parameters
